### PR TITLE
Remove "0;" characters from general meta tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ async function persistRecordWithMetadata(r) {
         .map(([key, value]) =>
           key === "refresh"
             ? `<meta http-equiv="${key}" content="0;${value}" />`
-            : `<meta name="${key}" content="0;${value}" />`
+            : `<meta name="${key}" content="${value}" />`
         )
         .join("\n")}
       </head></html>


### PR DESCRIPTION
These are added for the `http-equiv` meta tag, but are unnecessary for all other meta tag types.