### PR TITLE
feat: scope non-refresh to path

### DIFF
--- a/lib/router.ts
+++ b/lib/router.ts
@@ -55,9 +55,9 @@ const routeShortlink = async (req: Request): Promise<Response> => {
     return matchingResponse;
   }
 
-  // Refresh the cache if no match
+  // Refresh the cache for this path if no match
   try {
-    await refreshCache();
+    await refreshCache(path);
   } catch (err) {
     const message = "An internal error occured. Please try again later.";
     return new Response(message, { status: 500 });

--- a/lib/shortener.ts
+++ b/lib/shortener.ts
@@ -5,7 +5,7 @@ import cache from "./cache";
 import { fetchEntries } from "./google";
 import { LinkRecord } from "./types";
 
-export const refreshCache = async () => {
+export const refreshCache = async (path?: string) => {
   const rows = await fetchEntries();
 
   // Persist list of regex entries to cache
@@ -13,9 +13,11 @@ export const refreshCache = async () => {
   const regexEntriesPromise = cache.setRegexEntries(regexEntries);
 
   // Persist metadata of regular links to cache
-  const regularEntriesPromise = rows
-    .filter(r => !r.isRegex)
-    .map(persistRecordWithMetadata);
+  let regularEntries = rows.filter(r => !r.isRegex);
+  if (path) {
+    regularEntries = regularEntries.filter(r => r.from === path);
+  }
+  const regularEntriesPromise = regularEntries.map(persistRecordWithMetadata);
 
   return Promise.all([regexEntriesPromise, ...regularEntriesPromise]);
 };


### PR DESCRIPTION
This dramatically improves response time for new short links (or expired cache hits). Still store
all RegEx entries because these are very low overhead and there's no reason to duplicate RegEx
matching work.