### PR TITLE
fix: use timezone config for cache ttl

### DIFF
--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -2,6 +2,7 @@ import { DateTime } from 'luxon';
 import Redis from 'ioredis';
 import FakeRedis from 'ioredis-mock';
 
+import { config } from '../config';
 import { LinkRecord } from './types';
 
 const EntryCacheKeys = Object.freeze({
@@ -17,7 +18,7 @@ const TTL_404 = 5 * 60; // Five minutes
 
 // Expire record at the end of the day. Compute every time to prevent caching by Fly
 export const secondsToEod = (): number =>
-  Math.round(DateTime.now().endOf('day').diffNow('seconds').seconds);
+  Math.round(DateTime.now().setZone(config.timezone).endOf('day').diffNow('seconds').seconds);
 
 const pathKey = (path: string) => `${EntryCacheKeys.EntryTag}:${path}`;
 


### PR DESCRIPTION
Cache expiration was still happening at midnight UTC even with YYMMDD being calculated correctly in 9bba38873fa1701f689ced57fca4ea3fc607fe52.